### PR TITLE
Using a specific commit of Stomp Client and moved to Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM node:5.6-onbuild
+FROM alpine:3.4
+
+# Install nodejs
+RUN apk --no-cache add nodejs curl jq
 
 # Add source
 ADD . /forklift-gui
@@ -8,5 +11,4 @@ WORKDIR /forklift-gui
 # Expose the default node hosting port.
 EXPOSE 3000
 
-RUN chmod 755 /forklift-gui/bin/run
-ENTRYPOINT ["/forklift-gui/bin/run"]
+ENTRYPOINT ["/forklift-gui/bin/start"]

--- a/bin/run
+++ b/bin/run
@@ -1,2 +1,2 @@
-#!/usr/bin/env bash
-/usr/local/bin/npm start 
+#!/usr/bin/env sh
+/usr/local/bin/npm start

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "passport-google-oauth2": "^0.1.6",
     "request": "^2.72.0",
     "serve-favicon": "~2.2.1",
-    "stomp-client": "^0.8.1",
+    "stomp-client": "easternbloc/node-stomp-client#1a2e2ff00a44cf38da62213c6b51d2f46d75c38b",
     "stompit": "^0.23.0",
     "winston": "^2.1.1"
   }


### PR DESCRIPTION
fixed a header issue in stomp by using a specific commit build, moved forklift-gui to alpine for smaller images