### PR TITLE
updated stomp-client to version 0.9.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 *.env
 *.iml
 *.idea/
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,8 @@ WORKDIR /forklift-gui
 # Expose the default node hosting port.
 EXPOSE 3000
 
+
 ENTRYPOINT ["/forklift-gui/bin/start"]
+
+WORKDIR /forklift-gui
+RUN npm install

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "passport-google-oauth2": "^0.1.6",
     "request": "^2.72.0",
     "serve-favicon": "~2.2.1",
-    "stomp-client": "easternbloc/node-stomp-client#1a2e2ff00a44cf38da62213c6b51d2f46d75c38b",
+    "stomp-client": "0.9.0",
     "stompit": "^0.23.0",
     "winston": "^2.1.1"
   }


### PR DESCRIPTION
dependencies are now installed on docker build, the node_modules folder will no longer just be copied over from the users directory. stomp-client is now using version 0.9.0 which includes my pull requested changes and no longer looking at a specific commit. You can view the changes here: https://github.com/easternbloc/node-stomp-client/pull/63

