### PR TITLE
Fix view-log button

### DIFF
--- a/public/javascripts/dashboard.js
+++ b/public/javascripts/dashboard.js
@@ -37,20 +37,3 @@ $(".retryBtn").click(function() {
         });
     });
 });
-$("#viewLog").on('click', function(event) {
-  swal({
-    title: "Search for Log",
-    text: "Enter a log id for the log you'd like to view:",
-    type: "input",
-    showCancelButton: true,
-    confirmButtonText: 'Show me the log!',
-    inputPlaceholder: "Log Id"
-  }, function(input) {
-      if (input === false) return false;
-      if (input === "") {
-        swal.showInputError("Please enter a log id!");
-        return false;
-      }
-      window.open("log?id="+input, "_blank");
-  });
-});

--- a/public/javascripts/navbar.js
+++ b/public/javascripts/navbar.js
@@ -1,0 +1,20 @@
+$("#viewLog").on('click', function(event) {
+  swal({
+    title: "Search for Log",
+    text: "Enter a log id for the log you'd like to view:",
+    type: "input",
+    showCancelButton: true,
+    confirmButtonText: 'Show me the log!',
+    inputPlaceholder: "Log Id",
+    closeOnConfirm: false
+  }, function(input) {
+    if (input === false) return false;
+    if (input === "") {
+      swal.showInputError("Please enter a log id!");
+      return false;
+    }
+    window.open("log?id="+input, "_blank");
+    swal.close();
+  });
+});
+

--- a/public/stylesheets/navbar.css
+++ b/public/stylesheets/navbar.css
@@ -1,0 +1,3 @@
+.viewLog {
+    cursor: pointer;
+}

--- a/views/layouts/navbar.jade
+++ b/views/layouts/navbar.jade
@@ -1,4 +1,6 @@
 <!-- Navbar -->
+link(href='css/navbar.css', rel='stylesheet', media='screen')
+
 nav(class="navbar navbar-default navbar-static-top navbar-inverse")
     div(class="container-fluid")
         div(class="navbar-header")
@@ -18,8 +20,8 @@ nav(class="navbar navbar-default navbar-static-top navbar-inverse")
                     a(href="replays" id="searchReplay" name="replay")
                         span.glyphicon.glyphicon-warning-sign
                         |  Search Replay
-                li
-                    a#viewLog
+                li(class="viewLog")
+                    a(id="viewLog")
                         span.glyphicon.glyphicon-eye-open
                         |  View Log
 
@@ -32,4 +34,6 @@ nav(class="navbar navbar-default navbar-static-top navbar-inverse")
                     a(href="logout")
                         span(class="glyphicon glyphicon-log-out")
                         |  Logout
+script(src='js/jquery-1.11.3.min.js')
+script(src='js/navbar.js')
 <!-- End Navbar -->


### PR DESCRIPTION
The view log button wasn't styling, so it appeared as a text cursor.  Also, on subsequent pages, such as the replay queue, it ceased to function.  To fix this, I added a js and css file specifically for the navbar, and included them in the imports in the specific jade file, to ensure that they were active anywhere the navbar was applied.