### PR TITLE
Update for Replay / Retry Version 2

### DIFF
--- a/controllers/dashboardController.js
+++ b/controllers/dashboardController.js
@@ -9,10 +9,8 @@ module.exports.show = function (req, res) {
     if (process.env.FORKLIFT_GUI_AUTHORIZED_EMAIL_DOMAINS.indexOf(domain) > -1) {
         // get forklift gui stats
         elasticService.ping(function(alive) {
-            logger.info("Ping successful!");
             if (alive) {
                 elasticService.stats(function(stats) {
-                    logger.info('Got stats: ' + stats);
                     if (stats) {
                         res.render('dashboard', {currentUrl: '', stats: stats});
                     } else {

--- a/controllers/dashboardController.js
+++ b/controllers/dashboardController.js
@@ -9,8 +9,10 @@ module.exports.show = function (req, res) {
     if (process.env.FORKLIFT_GUI_AUTHORIZED_EMAIL_DOMAINS.indexOf(domain) > -1) {
         // get forklift gui stats
         elasticService.ping(function(alive) {
+            logger.info("Ping successful!");
             if (alive) {
                 elasticService.stats(function(stats) {
+                    logger.info('Got stats: ' + stats);
                     if (stats) {
                         res.render('dashboard', {currentUrl: '', stats: stats});
                     } else {

--- a/controllers/elasticSearchController.js
+++ b/controllers/elasticSearchController.js
@@ -17,6 +17,7 @@ var extractLog = function(log, i) {
         destination: val["destination-name"] || val["queue"],
         role: val["role"] || val["queue"],
         roleMessage: val["destination-message"] || val["text"],
+        text: val["text"],
         version: val["forklift-replay-version"] || val["forklift-retry-version"] || "1",
         stepCount: val["forklift-replay-step-count"],
 

--- a/controllers/elasticSearchController.js
+++ b/controllers/elasticSearchController.js
@@ -54,8 +54,8 @@ module.exports.updateStep = function(req, res) {
     });
 };
 module.exports.updateAllAsFixed = function(req, res) {
-    var queue = req.body.queue;
-    elasticService.poll('replay', queue, 10000, function(logs, err) {
+    var role = req.body.role;
+    elasticService.poll('replay', role, 10000, function(logs, err) {
         if (logs === 'undefined' || logs == null) {
             req.flash('error', err);
         }

--- a/controllers/elasticSearchController.js
+++ b/controllers/elasticSearchController.js
@@ -18,9 +18,12 @@ var extractLog = function(log, i) {
         role: val["role"] || val["queue"],
         roleMessage: val["destination-message"] || val["text"],
         version: val["forklift-replay-version"] || val["forklift-retry-version"] || "1",
+        stepCount: val["step-count"],
 
         retryCount: val["forklift-retry-count"],
         maxRetryCount: val["forklift-retry-max-retries"],
+        // a bit hacky, ensures logs display when there are no retry properties
+        retriesDone: val["forklift-retry-count"] == val["forklift-retry-max-retries"],
 
         messageId: "message-" + i,
         correlationId: log._id
@@ -129,11 +132,7 @@ module.exports.showRetries = function(req, res) {
         if (logs === 'undefined' || logs == null) {
             req.flash('error', err);
         }
-        var hits = [];
-        for (var i = 0; i < logs.length; i++) {
-            hits.push(logs[i]);
-        }
-        res.render('log-display', {currentUrl: 'retries', hits: hits, extractLog: extractLog})
+        res.render('log-display', {currentUrl: 'retries', hits: logs, extractLog: extractLog});
     });
 };
 module.exports.showReplays = function(req, res) {
@@ -141,11 +140,7 @@ module.exports.showReplays = function(req, res) {
         if (logs === 'undefined' || logs == null) {
             req.flash('error', err);
         }
-        var hits = [];
-        for (var i = 0; i < logs.length; i++) {
-            hits.push(logs[i]);
-        }
-        res.render('log-display', {currentUrl: 'replays', hits: hits, extractLog: extractLog})
+        res.render('log-display', {currentUrl: 'replays', hits: logs, extractLog: extractLog});
     });
 };
 module.exports.showFilteredResults = function(req, res) {
@@ -157,10 +152,6 @@ module.exports.showFilteredResults = function(req, res) {
         if (logs === 'undefined' || logs == null) {
             req.flash('error', err);
         }
-        var hits = [];
-        for (var i = 0; i < logs.length; i++) {
-            hits.push(logs[i]);
-        }
-        res.render('log-display', {currentUrl: service, hits: hits, extractLog: extractLog});
+        res.render('log-display', {currentUrl: service, hits: logs, extractLog: extractLog});
     });
 };

--- a/controllers/elasticSearchController.js
+++ b/controllers/elasticSearchController.js
@@ -18,7 +18,7 @@ var extractLog = function(log, i) {
         role: val["role"] || val["queue"],
         roleMessage: val["destination-message"] || val["text"],
         version: val["forklift-replay-version"] || val["forklift-retry-version"] || "1",
-        stepCount: val["step-count"],
+        stepCount: val["forklift-replay-step-count"],
 
         retryCount: val["forklift-retry-count"],
         maxRetryCount: val["forklift-retry-max-retries"],
@@ -60,7 +60,7 @@ module.exports.updateAllAsFixed = function(req, res) {
             req.flash('error', err);
         }
         for (var i = 0; i < logs.length; i++) {
-            var stepCount = logs[i]._source['step-count'];
+            var stepCount = logs[i]._source['forklift-replay-step-count'];
             elasticService.update(logs[i]._index, logs[i]._id, 'Fixed', stepCount, function() {
             })
         }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "body-parser": "~1.12.4",
     "connect-flash": "^0.1.1",
+    "consul": "0.28.0",
     "cookie-parser": "~1.3.5",
     "cookie-session": "^2.0.0-alpha.1",
     "dateformat": "^1.0.12",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "moment": "^2.16.0",
     "morgan": "~1.5.3",
     "nodemailer": "^2.4.2",
+    "no-kafka": "3.1.4",
     "passport": "^0.3.2",
     "passport-google-oauth2": "^0.1.6",
     "request": "^2.72.0",

--- a/public/javascripts/hits.js
+++ b/public/javascripts/hits.js
@@ -1,11 +1,12 @@
 $('[data-toggle="tooltip"]').tooltip();
+
 var pathnameSize = window.location.pathname.split('/').length - 1;
 if (window.location.pathname.split('/')[pathnameSize] == "replays" ||
     (window.location.pathname.split('/')[pathnameSize] == "filtered" &&
      window.location.search.split("&")[0] == "?service=replays")) {
     $(".mouseOver").mouseover(function () {
-        var messageId = $(this).parent().attr('id');
-        var errorHtml = $("#pre-error" + messageId).html();
+        var errorHtml = $(this).parent().parent().find(".msgError pre").html();
+
         $(this).parent().parent().find(".errorHoverDisplay").html(errorHtml);
         $(this).parent().parent().find(".errorHoverDisplay").show();
     }).mouseout(function () {
@@ -65,11 +66,18 @@ $('.retryButton').click(function () {
     var correlationId = $(this).attr('correlationId');
     var text = $(this).attr('text');
     var queue = $(this).attr('queue');
-    $.post('retry', {
+    var connector  = $(this).attr('connector')
+    var serializedMessage = $(this).attr('serializedMessage')
+
+    var retryMsg = {
+        connector: connector,
+        queue: queue,
         correlationId: correlationId,
         text: text,
-        queue: queue
-    }, function() {
+        serializedMessage: serializedMessage
+    }
+
+    $.post('retry', retryMsg, function() {
         $("#"+messageId).parent().remove();
     });
 });

--- a/public/javascripts/hits.js
+++ b/public/javascripts/hits.js
@@ -1,3 +1,4 @@
+
 $('[data-toggle="tooltip"]').tooltip();
 
 var pathnameSize = window.location.pathname.split('/').length - 1;
@@ -63,22 +64,27 @@ $("#fixAllButton").click(function() {
 });
 $('.retryButton').click(function () {
     var messageId = $(this).attr('messageId');
+
+    var connector  = $(this).attr('connector');
+    var role = $(this).attr('role');
+    var roleMessage  = $(this).attr('roleMessage');
+
     var correlationId = $(this).attr('correlationId');
     var text = $(this).attr('text');
     var queue = $(this).attr('queue');
-    var connector  = $(this).attr('connector')
-    var serializedMessage = $(this).attr('serializedMessage')
 
     var retryMsg = {
         connector: connector,
-        queue: queue,
-        correlationId: correlationId,
+        role: role,
+        roleMessage: roleMessage,
+        // legacy attributes
         text: text,
-        serializedMessage: serializedMessage
-    }
+        correlationId: correlationId,
+        queue: queue
+    };
 
     $.post('retry', retryMsg, function() {
-        $("#"+messageId).parent().remove();
+        $("#"+messageId).remove();
     });
 });
 $('.fixButton').click(function () {
@@ -90,7 +96,7 @@ $('.fixButton').click(function () {
         index: index,
         step: "Fixed"
     }, function() {
-        $("#"+messageId).parent().remove();
+        $("#"+messageId).remove();
     });
 });
 $('.changeQueueButton').click(function () {
@@ -115,7 +121,7 @@ $('.changeQueueButton').click(function () {
             text: text,
             queue: inputValue
         }, function() {
-            $("#"+messageId).parent().remove();
+            $("#"+messageId).remove();
         });
         swal.close();
     });
@@ -155,7 +161,7 @@ $('.changeStepButton').click(function () {
       text: text,
       queue: queue
     }, function () {
-      $("#" + messageId).parent().remove();
+      $("#" + messageId).remove();
     });
     swal.close();
   });

--- a/public/javascripts/hits.js
+++ b/public/javascripts/hits.js
@@ -102,28 +102,52 @@ $('.fixButton').click(function () {
         $("#"+messageId).remove();
     });
 });
-$('.changeQueueButton').click(function () {
+$('.sendToButton').click(function () {
     var messageId = $(this).attr('messageId');
-    var correlationId = $(this).attr('correlationId');
+    var sendType = $(this).attr('sendType');
+
+    var connector  = $(this).attr('connector');
+    var version = $(this).attr('version');
+    var role = $(this).attr('role');
+    var destination  = $(this).attr('destination');
+    var roleMessage  = $(this).attr('roleMessage');
     var text = $(this).attr('text');
+
+    var correlationId = $(this).attr('correlationId');
+
     swal({
-        title: "Change Queue",
-        text: "please input the queue you'd like this document to be sent",
+        title: "Send To New Destination",
+        text: "please input the destination to which you'd like this document to be sent",
         type: "input",
         showCancelButton: true,
         closeOnConfirm: false,
-        inputPlaceholder: "desired queue..."
+        inputPlaceholder: "desired destination..."
     }, function(inputValue) {
         if (inputValue === false) return false;
         if (inputValue === "") {
-            swal.showInputError("You need to provide a queue");
+            swal.showInputError("You need to provide a destination");
             return false;
         }
-        $.post('retry', {
-            correlationId: correlationId,
-            text: text,
-            queue: inputValue
-        }, function() {
+
+        var destination;
+        if (sendType === 'role') {
+            destination = 'forklift-role-' + inputValue;
+        } else if (sendType == 'raw') {
+            destination = inputValue;
+            roleMessage = text;
+        }
+
+        var retryMsg = {
+            connector: connector,
+            role: role,
+            destination: destination,
+            roleMessage: roleMessage,
+            version: version,
+            // carry this on for AMQ
+            correlationId: correlationId
+        };
+
+        $.post('retry', retryMsg, function() {
             $("#"+messageId).remove();
         });
         swal.close();

--- a/public/javascripts/hits.js
+++ b/public/javascripts/hits.js
@@ -66,21 +66,21 @@ $('.retryButton').click(function () {
     var messageId = $(this).attr('messageId');
 
     var connector  = $(this).attr('connector');
+    var version = $(this).attr('version');
     var role = $(this).attr('role');
+    var destination  = $(this).attr('destination');
     var roleMessage  = $(this).attr('roleMessage');
 
     var correlationId = $(this).attr('correlationId');
-    var text = $(this).attr('text');
-    var queue = $(this).attr('queue');
 
     var retryMsg = {
         connector: connector,
         role: role,
+        destination: destination,
         roleMessage: roleMessage,
-        // legacy attributes
-        text: text,
-        correlationId: correlationId,
-        queue: queue
+        version: version,
+        // carry this on for AMQ
+        correlationId: correlationId
     };
 
     $.post('retry', retryMsg, function() {

--- a/public/javascripts/hits.js
+++ b/public/javascripts/hits.js
@@ -21,19 +21,19 @@ $('.modifyBtns').click(function (evt) {
 $("#filterButton").click(function() {
     var service = $(this).attr('service');
     swal({
-        title: "Filter by Queue",
-        text: "Input the queue you would like to view logs for",
+        title: "Filter by Role",
+        text: "Input the role you would like to view logs for",
         type: "input",
         showCancelButton: true,
         closeOnConfirm: false,
-        inputPlaceholder: "desired queue..."
+        inputPlaceholder: "desired role..."
     }, function(inputValue) {
         if (inputValue === false) return false;
         if (inputValue === "") {
-            swal.showInputError("You need to provide a queue");
+            swal.showInputError("You need to provide a role");
             return false;
         }
-        window.location = "filtered?service="+service+"&queue="+inputValue;
+        window.location = "filtered?service="+service+"&role="+inputValue;
         swal.close();
     });
 });

--- a/public/javascripts/hits.js
+++ b/public/javascripts/hits.js
@@ -40,19 +40,19 @@ $("#filterButton").click(function() {
 $("#fixAllButton").click(function() {
     swal({
         title: "Fix All",
-        text: "Set all logs as fixed for desired queue, no going back",
+        text: "Set all logs as fixed for desired role, no going back",
         type: "input",
         showCancelButton: true,
         closeOnConfirm: false,
-        inputPlaceholder: "desired queue..."
+        inputPlaceholder: "desired role..."
     }, function(inputValue) {
         if (inputValue === false) return false;
         if (inputValue === "") {
-            swal.showInputError("You need to provide a queue");
+            swal.showInputError("You need to provide a role");
             return false;
         }
         $.post('fixAll', {
-            queue: inputValue
+            role: inputValue
         }, function() {
             setTimeout(function() {
                 location.reload();

--- a/public/javascripts/hits.js
+++ b/public/javascripts/hits.js
@@ -91,10 +91,13 @@ $('.fixButton').click(function () {
     var messageId = $(this).attr('messageId');
     var updateId = $(this).attr('logId');
     var index = $(this).attr('index');
+    var stepCount = $(this).attr('stepCount');
+
     $.post('updateStep', {
         updateId: updateId,
         index: index,
-        step: "Fixed"
+        step: "Fixed",
+        stepCount: stepCount
     }, function() {
         $("#"+messageId).remove();
     });
@@ -128,41 +131,56 @@ $('.changeQueueButton').click(function () {
 });
 
 $('.changeStepButton').click(function () {
-  var messageId = $(this).attr('messageId');
-  var updateId = $(this).attr('logId');
-  var index = $(this).attr('index');
-  var correlationId = $(this).attr('correlationId');
-  var text = $(this).attr('text');
-  var queue = $(this).attr('queue');
-  swal({
-    title: "Change Step",
-    text: "please enter the step name for this log",
-    type: "input",
-    showCancelButton: true,
-    closeOnConfirm: false,
-    inputPlaceholder: "Fixed, Error, or Pending"
-  }, function(inputValue) {
-    if (inputValue === false) return false;
-    if (inputValue === "") {
-      swal.showInputError("You need to provide a step name");
-      return false;
-    }
-    if (inputValue !== "Fixed" &&
-      inputValue !== "Error" &&
-      inputValue !== "Pending") {
-      swal.showInputError("Please enter [Fixed, Error, Pending] as the value.");
-      return false;
-    }
-    $.post('updateStep', {
-      updateId: updateId,
-      index: index,
-      step: inputValue,
-      correlationId: correlationId,
-      text: text,
-      queue: queue
-    }, function () {
-      $("#" + messageId).remove();
+    var logId = $(this).attr('logId');
+    var messageId = $(this).attr('messageId');
+    var index = $(this).attr('index');
+
+    var connector  = $(this).attr('connector');
+    var version = $(this).attr('version');
+    var role = $(this).attr('role');
+    var destination  = $(this).attr('destination');
+    var roleMessage  = $(this).attr('roleMessage');
+
+    var stepCount = $(this).attr('stepCount');
+
+    var correlationId = $(this).attr('correlationId');
+
+    swal({
+        title: "Change Step",
+        text: "please enter the step name for this log",
+        type: "input",
+        showCancelButton: true,
+        closeOnConfirm: false,
+        inputPlaceholder: "Fixed, Error, or Pending"
+    }, function(inputValue) {
+        if (inputValue === false) return false;
+        if (inputValue === "") {
+            swal.showInputError("You need to provide a step name");
+            return false;
+        }
+        if (inputValue !== "Fixed" &&
+            inputValue !== "Error" &&
+            inputValue !== "Pending") {
+            swal.showInputError("Please enter [Fixed, Error, Pending] as the value.");
+            return false;
+        }
+        $.post('updateStep', {
+            updateId: logId,
+            index: index,
+            step: inputValue,
+            stepCount: stepCount,
+
+            // retry info
+            connector: connector,
+            role: role,
+            destination: destination,
+            roleMessage: roleMessage,
+            version: version,
+            // carry this on for AMQ
+            correlationId: correlationId
+        }, function () {
+            $("#" + messageId).remove();
+        });
+        swal.close();
     });
-    swal.close();
-  });
 });

--- a/services/elasticService.js
+++ b/services/elasticService.js
@@ -64,8 +64,6 @@ service.get = function(id, done) {
 service.poll = function(service, role, size, done) {
     var index = 'forklift-'+service+'*';
 
-    logger.info("Polling: " + index + " for role " + role);
-
     var query;
     if (role == null) {
         query = {
@@ -151,10 +149,8 @@ service.sendToKafka = function(msg, done) {
 
 service.stats = function(done) {
     getStats('forklift-retry*', function(retryStats) {
-        logger.info("retry stats done " + JSON.stringify(retryStats));
         getStats('forklift-replay*', function(replayStats) {
-            logger.info("replay stats done " + JSON.stringify(replayStats));
-            return done({
+            done({
                 replay: replayStats,
                 retry: retryStats
             })
@@ -186,10 +182,8 @@ var getStats = function(index, done) {
             var role = hit['role'] || hit['queue'];
             roleTotals[role] = (roleTotals[role] || 0) + 1;
 
-            logger.info("DInfo: " + role + " " + roleTotals[role]);
         });
-        logger.info("Finished stats");
-        return done({
+        done({
             totalLogs: size,
             roleTotals: roleTotals
         });

--- a/services/elasticService.js
+++ b/services/elasticService.js
@@ -111,7 +111,7 @@ service.update = function(index, updateId, step, done) {
     });
 };
 
-service.retry = function(correlationId, text, queue, done) {
+service.retryActiveMqMessage = function(correlationId, text, queue, done) {
     var msg = {
         jmsHeaders : { 'correlation-id' : correlationId },
         body : text,
@@ -126,6 +126,11 @@ service.retry = function(correlationId, text, queue, done) {
     stompClient.publish(msg.queue, msg.body, msg.jmsHeaders);
     done();
 };
+
+service.retryKafkaMessage = function(text, serializedText, topic, done) {
+    log.warn('Retrying messages to kafka is currently not supported');
+    done();
+}
 
 service.stats = function(done) {
     getStats('forklift-retry*', function(retryStats) {

--- a/services/elasticService.js
+++ b/services/elasticService.js
@@ -64,9 +64,8 @@ service.get = function(id, done) {
         size: 1,
         body: {
             query: {
-                query_string: {
-                    query: id,
-                    fields: ["_id"]
+                term: {
+                    '_id': id
                 }
             }
         }

--- a/services/elasticService.js
+++ b/services/elasticService.js
@@ -100,8 +100,8 @@ service.poll = function(service, role, size, done) {
     });
 };
 
-service.update = function(index, updateId, step, done) {
-    client.update({
+service.update = function(index, updateId, step, version, done) {
+    var updateRequest = {
         index: index,
         id: updateId,
         type: 'log',
@@ -110,7 +110,14 @@ service.update = function(index, updateId, step, done) {
                 step: step
             }
         }
-    }, function (err) {
+    };
+
+    if (version) {
+        updateRequest.version = version;
+        updateRequest.versionType = 'force';
+    }
+
+    client.update(updateRequest, function (err) {
         if (err) {
             logger.error(err);
         }

--- a/services/elasticService.js
+++ b/services/elasticService.js
@@ -79,7 +79,8 @@ service.poll = function(service, role, size, done) {
                 should: [
                     {match: {"queue": role}},
                     {match: {"role": role}}
-                ]
+                ],
+                minimum_should_match: 1
             }
         };
     }

--- a/views/dashboard.jade
+++ b/views/dashboard.jade
@@ -34,11 +34,9 @@ html
                             hr
                             if stats.retry.totalLogs > 0
                                 h3.text-uppercase Total Error Logs - #{stats.retry.totalLogs}
-                                if stats.retry.queues.length > 0
-                                    - for (var i = 0; i < stats.retry.queues.length; i++)
-                                        - var queue = stats.retry.queues[i]
-                                        - var queueTotal = stats.retry.queueTotals[i]
-                                        a.btn.btn-info.btn-lg.btn-block.text-uppercase(href="filtered?service=retries&queue=" + queue) #{queue} - #{queueTotal}
+                                  - for (var role in stats.retry.roleTotals)
+                                      - var roleTotal = stats.retry.roleTotals[role]
+                                      a.btn.btn-info.btn-lg.btn-block.text-uppercase(href="filtered?service=retries&role=" + role) #{role} - #{roleTotal}
                             else
                                 div.alert.alert-success
                                     h1.noListings.text-center NO RETRY LOGS FOUND
@@ -48,11 +46,9 @@ html
                             hr
                             if stats.replay.totalLogs > 0
                                 h3.text-uppercase Total Error Logs - #{stats.replay.totalLogs}
-                                if stats.replay.queues.length > 0
-                                    - for (var i = 0; i < stats.replay.queues.length; i++)
-                                        - var queue = stats.replay.queues[i]
-                                        - var queueTotal = stats.replay.queueTotals[i]
-                                        a.queueBtn.btn.btn-info.btn-lg.text-uppercase(href="filtered?service=replays&queue=" + queue) #{queue} - #{queueTotal}
+                                    - for (var role in stats.replay.roleTotals)
+                                        - var roleTotal = stats.replay.roleTotals[role]
+                                        a.queueBtn.btn.btn-info.btn-lg.text-uppercase(href="filtered?service=replays&role=" + role) #{role} - #{roleTotal}
                                         .btn.queueModBtn.retryBtn.btn-primary.btn-lg.text-uppercase(queue=queue data-toggle="tooltip" title="Will retry all logs in queue")
                                             span.glyphicon.glyphicon-retweet
                                         .btn.queueModBtn.fixBtn.btn-danger.btn-lg.text-uppercase(queue=queue data-toggle="tooltip" title="Will mark all logs in queue as fixed")

--- a/views/dashboard.jade
+++ b/views/dashboard.jade
@@ -34,9 +34,9 @@ html
                             hr
                             if stats.retry.totalLogs > 0
                                 h3.text-uppercase Total Error Logs - #{stats.retry.totalLogs}
-                                  - for (var role in stats.retry.roleTotals)
-                                      - var roleTotal = stats.retry.roleTotals[role]
-                                      a.btn.btn-info.btn-lg.btn-block.text-uppercase(href="filtered?service=retries&role=" + role) #{role} - #{roleTotal}
+                                - for (var role in stats.retry.roleTotals)
+                                    - var roleTotal = stats.retry.roleTotals[role]
+                                    a.btn.btn-info.btn-lg.btn-block.text-uppercase(href="filtered?service=retries&role=" + role) #{role} - #{roleTotal}
                             else
                                 div.alert.alert-success
                                     h1.noListings.text-center NO RETRY LOGS FOUND
@@ -46,13 +46,13 @@ html
                             hr
                             if stats.replay.totalLogs > 0
                                 h3.text-uppercase Total Error Logs - #{stats.replay.totalLogs}
-                                    - for (var role in stats.replay.roleTotals)
-                                        - var roleTotal = stats.replay.roleTotals[role]
-                                        a.queueBtn.btn.btn-info.btn-lg.text-uppercase(href="filtered?service=replays&role=" + role) #{role} - #{roleTotal}
-                                        .btn.queueModBtn.retryBtn.btn-primary.btn-lg.text-uppercase(queue=queue data-toggle="tooltip" title="Will retry all logs in queue")
-                                            span.glyphicon.glyphicon-retweet
-                                        .btn.queueModBtn.fixBtn.btn-danger.btn-lg.text-uppercase(queue=queue data-toggle="tooltip" title="Will mark all logs in queue as fixed")
-                                            span.glyphicon.glyphicon-fire
+                                - for (var role in stats.replay.roleTotals)
+                                    - var roleTotal = stats.replay.roleTotals[role]
+                                    a.queueBtn.btn.btn-info.btn-lg.text-uppercase(href="filtered?service=replays&role=" + role) #{role} - #{roleTotal}
+                                    .btn.queueModBtn.retryBtn.btn-primary.btn-lg.text-uppercase(queue=queue data-toggle="tooltip" title="Will retry all logs in queue")
+                                        span.glyphicon.glyphicon-retweet
+                                    .btn.queueModBtn.fixBtn.btn-danger.btn-lg.text-uppercase(queue=queue data-toggle="tooltip" title="Will mark all logs in queue as fixed")
+                                        span.glyphicon.glyphicon-fire
                             else
                                 div.alert.alert-success
                                     h1.noListings.text-center NO REPLAY LOGS FOUND

--- a/views/layouts/log.jade
+++ b/views/layouts/log.jade
@@ -15,7 +15,7 @@ a.list-group-item(id=messageId)
                 button.modifyBtns.btn.btn-sm.btn-success.changeStepButton(type="button" messageId=messageId logId=logId correlationId=correlationId index=logIndex text=val.text queue=val.queue)
                     span.glyphicon.glyphicon-step-forward
                     |  Change Step
-                button.modifyBtns.btn.btn-sm.btn-success.changeQueueButton(type="button" messageId=messageId logId=logId correlationId=correlationId index=logIndex text=val.text queue=val.queue)
+                button.modifyBtns.btn.btn-sm.btn-success.changeQueueButton(type="button" messageId=messageId logId=logId correlationId=correlationId index=logIndex text=val.text queue=val.queue disabled=(val.connector == 'KafkaConnector'))
                     span.glyphicon.glyphicon-pencil
                     |  Change Queue
                 button.modifyBtns.btn.btn-sm.btn-info(onclick="window.location.href='log?id="+logId+"'" data-toggle="tooltip" title="Opens log in a shareable url")
@@ -25,7 +25,7 @@ a.list-group-item(id=messageId)
     div.collapse.listCollapse
         .row.listing-details
             span.badge
-                span #{val.connector} ID: #{correlationId}
+                span #{val.connector || "ActiveMQConnector"} ID: #{correlationId}
         if val.text || val.errors
             if val.text
                 .btn-toolbar

--- a/views/layouts/log.jade
+++ b/views/layouts/log.jade
@@ -15,9 +15,10 @@ a.list-group-item(id=log.messageId)
                 button.modifyBtns.btn.btn-sm.btn-success.changeStepButton(type="button" messageId=log.messageId logId=log.logId correlationId=log.correlationId index=log.logIndex destination=log.destination connector=log.connector roleMessage=log.roleMessage role=log.role version=log.version stepCount=log.stepCount)
                     span.glyphicon.glyphicon-step-forward
                     |  Change Step
-                button.modifyBtns.btn.btn-sm.btn-success.sendToButton(type="button" messageId=log.messageId logId=log.logId correlationId=log.correlationId index=log.logIndex destination=log.destination connector=log.connector roleMessage=log.roleMessage role=log.role version=log.version sendType='role')
-                    span.glyphicon.glyphicon-pencil
-                    |  Change Role
+                if log.version === "2"
+                    button.modifyBtns.btn.btn-sm.btn-success.sendToButton(type="button" messageId=log.messageId logId=log.logId correlationId=log.correlationId index=log.logIndex destination=log.destination connector=log.connector roleMessage=log.roleMessage role=log.role version=log.version sendType='role')
+                        span.glyphicon.glyphicon-pencil
+                        |  Change Role
                 if log.connector === "ActiveMQConnector"
                     button.modifyBtns.btn.btn-sm.btn-success.sendToButton(type="button" messageId=log.messageId logId=log.logId correlationId=log.correlationId index=log.logIndex destination=log.destination connector=log.connector text=log.text role=log.role version=log.version sendType='raw')
                         span.glyphicon.glyphicon-share-alt

--- a/views/layouts/log.jade
+++ b/views/layouts/log.jade
@@ -1,24 +1,24 @@
-a.list-group-item(id=messageId)
-    div(data-toggle="collapse" data-target="#" + messageId + " .listCollapse")
+a.list-group-item(id=log.messageId)
+    div(data-toggle="collapse" data-target="#" + log.messageId + " .listCollapse")
         div.list-group-item-heading.mouseOver
-            span.badge.pull-right=moment(timestamp).format("lll")
-            h2.queue=role
+            span.badge.pull-right=moment(log.time).format("lll")
+            h2.queue=log.role
         hr
         div.btn-toolbar
             if currentUrl === 'replays'
-                button.modifyBtns.btn.btn-sm.btn-primary.retryButton(type="button" messageId=messageId logId=logId correlationId=correlationId index=logIndex destination=destination connector=connector roleMessage=roleMessage role=role version=version)
+                button.modifyBtns.btn.btn-sm.btn-primary.retryButton(type="button" messageId=log.messageId logId=log.logId correlationId=log.correlationId index=log.logIndex destination=log.destination connector=log.connector roleMessage=log.roleMessage role=log.role version=log.version)
                     span.glyphicon.glyphicon-repeat
                     |  Retry
-                button.modifyBtns.btn.btn-sm.btn-primary.fixButton(type="button" messageId=messageId logId=logId correlationId=correlationId index=logIndex role=role)
+                button.modifyBtns.btn.btn-sm.btn-primary.fixButton(type="button" messageId=log.messageId logId=log.logId correlationId=log.correlationId index=log.logIndex role=log.role)
                     span.glyphicon.glyphicon-ok
                     |  Fixed
-                button.modifyBtns.btn.btn-sm.btn-success.changeStepButton(type="button" messageId=messageId logId=logId correlationId=correlationId index=logIndex)
+                button.modifyBtns.btn.btn-sm.btn-success.changeStepButton(type="button" messageId=log.messageId logId=log.logId correlationId=log.correlationId index=log.logIndex)
                     span.glyphicon.glyphicon-step-forward
                     |  Change Step
-                button.modifyBtns.btn.btn-sm.btn-success.changeQueueButton(type="button" messageId=messageId logId=logId correlationId=correlationId index=logIndex text=val.text queue=val.queue)
+                button.modifyBtns.btn.btn-sm.btn-success.changeQueueButton(type="button" messageId=log.messageId logId=log.logId correlationId=log.correlationId index=log.logIndex)
                     span.glyphicon.glyphicon-pencil
                     |  Change Queue
-                button.modifyBtns.btn.btn-sm.btn-info(onclick="window.location.href='log?id="+logId+"'" data-toggle="tooltip" title="Opens log in a shareable url")
+                button.modifyBtns.btn.btn-sm.btn-info(onclick="window.location.href='log?id="+log.logId+"'" data-toggle="tooltip" title="Opens log in a shareable url")
                     span.glyphicon.glyphicon-link
                     | Share Link
             img.toggle-arrow.pull-right(src='img/toggle_arrow.svg', data-toggle='tooltip', title='Arrow')
@@ -27,40 +27,40 @@ a.list-group-item(id=messageId)
             tbody
                 tr
                     th Connector
-                    td #{connector}
+                    td #{log.connector}
                 tr
                     th ID
-                    td #{logId}
+                    td #{log.logId}
                 tr
                     th DestinationType
-                    td #{val["destination-type"] || "queue"}
+                    td #{log.val["destination-type"] || "queue"}
                 tr
                     th DestinationName
-                    td #{destination}
-                if val["source-description"]
+                    td #{log.destination}
+                if log.val["source-description"]
                     tr
                         th SourceDescription
-                        td #{val["source-description"]}
+                        td #{log.val["source-description"]}
                 tr
-                    th ReplayVersion
-                    td #{version || "1"}
+                    th LogVersion
+                    td #{log.version}
 
-        if val.text
+        if log.val.text
             .btn-toolbar
-                div.viewInfoBtn.btn.btn-sm.btn-info(data-toggle="collapse" data-target="#" + messageId + " .msgJson") View Json&nbsp;
+                div.viewInfoBtn.btn.btn-sm.btn-info(data-toggle="collapse" data-target="#" + log.messageId + " .msgJson") View Json&nbsp;
                     span.glyphicon.glyphicon-chevron-down
             div.collapse.msgJson
                 pre
-                    code.json=val.text
-        if val.errors
+                    code.json=log.val.text
+        if log.val.errors
             .btn-toolbar
-                div.viewInfoBtn.btn.btn-sm.btn-danger(type="button" data-toggle="collapse" data-target="#" + messageId + " .msgError") View Error&nbsp;
+                div.viewInfoBtn.btn.btn-sm.btn-danger(type="button" data-toggle="collapse" data-target="#" + log.messageId + " .msgError") View Error&nbsp;
                     span.glyphicon.glyphicon-chevron-down
             div.collapse.msgError
                 pre
-                    code.java=val.errors
+                    code.java=log.val.errors
     if currentUrl == 'retries'
         h5.queue
             b Retry Count •
-            |  #{retryCount} / #{maxRetryCount}
+            |  #{log.retryCount} / #{log.maxRetryCount}
     .errorHoverDisplay

--- a/views/layouts/log.jade
+++ b/views/layouts/log.jade
@@ -2,17 +2,17 @@ a.list-group-item(id=messageId)
     div(data-toggle="collapse" data-target="#" + messageId + " .listCollapse")
         div.list-group-item-heading.mouseOver
             span.badge.pull-right=moment(timestamp).format("lll")
-            h2.queue=val.queue
+            h2.queue=role
         hr
-        if currentUrl === 'replays'
-            div.btn-toolbar
-                button.modifyBtns.btn.btn-sm.btn-primary.retryButton(type="button" messageId=messageId logId=logId correlationId=correlationId index=logIndex text=val.text queue=val.queue connector=val.connector roleMessage=val['role-message'] role=val['role'])
+        div.btn-toolbar
+            if currentUrl === 'replays'
+                button.modifyBtns.btn.btn-sm.btn-primary.retryButton(type="button" messageId=messageId logId=logId correlationId=correlationId index=logIndex destination=destination connector=connector roleMessage=roleMessage role=role version=version)
                     span.glyphicon.glyphicon-repeat
                     |  Retry
-                button.modifyBtns.btn.btn-sm.btn-primary.fixButton(type="button" messageId=messageId logId=logId correlationId=correlationId index=logIndex text=val.text queue=val.queue)
+                button.modifyBtns.btn.btn-sm.btn-primary.fixButton(type="button" messageId=messageId logId=logId correlationId=correlationId index=logIndex role=role)
                     span.glyphicon.glyphicon-ok
                     |  Fixed
-                button.modifyBtns.btn.btn-sm.btn-success.changeStepButton(type="button" messageId=messageId logId=logId correlationId=correlationId index=logIndex text=val.text queue=val.queue)
+                button.modifyBtns.btn.btn-sm.btn-success.changeStepButton(type="button" messageId=messageId logId=logId correlationId=correlationId index=logIndex)
                     span.glyphicon.glyphicon-step-forward
                     |  Change Step
                 button.modifyBtns.btn.btn-sm.btn-success.changeQueueButton(type="button" messageId=messageId logId=logId correlationId=correlationId index=logIndex text=val.text queue=val.queue)
@@ -21,26 +21,44 @@ a.list-group-item(id=messageId)
                 button.modifyBtns.btn.btn-sm.btn-info(onclick="window.location.href='log?id="+logId+"'" data-toggle="tooltip" title="Opens log in a shareable url")
                     span.glyphicon.glyphicon-link
                     | Share Link
-        img.toggle-arrow.pull-right(src='img/toggle_arrow.svg', data-toggle='tooltip', title='Arrow')
+            img.toggle-arrow.pull-right(src='img/toggle_arrow.svg', data-toggle='tooltip', title='Arrow')
     div.collapse.listCollapse
-        .row.listing-details
-            span.badge
-                span #{val.connector || "ActiveMQConnector"} ID: #{correlationId}
-        if val.text || val.errors
-            if val.text
-                .btn-toolbar
-                    div.viewInfoBtn.btn.btn-sm.btn-info(data-toggle="collapse" data-target="#" + messageId + " .msgJson") View Json&nbsp;
-                        span.glyphicon.glyphicon-chevron-down
-                div.collapse.msgJson
-                    pre
-                        code.json=JSON.stringify(val.text, null, 2)
-            if val.errors
-                .btn-toolbar
-                    div.viewInfoBtn.btn.btn-sm.btn-danger(type="button" data-toggle="collapse" data-target="#" + messageId + " .msgError") View Error&nbsp;
-                        span.glyphicon.glyphicon-chevron-down
-                div.collapse.msgError
-                    pre
-                        code.java=val.errors
+        table.table
+            tbody
+                tr
+                    th Connector
+                    td #{connector}
+                tr
+                    th ID
+                    td #{logId}
+                tr
+                    th DestinationType
+                    td #{val["destination-type"] || "queue"}
+                tr
+                    th DestinationName
+                    td #{destination}
+                if val["source-description"]
+                    tr
+                        th SourceDescription
+                        td #{val["source-description"]}
+                tr
+                    th ReplayVersion
+                    td #{version || "1"}
+
+        if val.text
+            .btn-toolbar
+                div.viewInfoBtn.btn.btn-sm.btn-info(data-toggle="collapse" data-target="#" + messageId + " .msgJson") View Json&nbsp;
+                    span.glyphicon.glyphicon-chevron-down
+            div.collapse.msgJson
+                pre
+                    code.json=val.text
+        if val.errors
+            .btn-toolbar
+                div.viewInfoBtn.btn.btn-sm.btn-danger(type="button" data-toggle="collapse" data-target="#" + messageId + " .msgError") View Error&nbsp;
+                    span.glyphicon.glyphicon-chevron-down
+            div.collapse.msgError
+                pre
+                    code.java=val.errors
     if currentUrl == 'retries'
         h5.queue
             b Retry Count •

--- a/views/layouts/log.jade
+++ b/views/layouts/log.jade
@@ -1,12 +1,12 @@
-a.list-group-item
-    div(id=messageId data-toggle="collapse" data-target="#listCollapse" + messageId)
+a.list-group-item(id=messageId)
+    div(data-toggle="collapse" data-target="#" + messageId + " .listCollapse")
         div.list-group-item-heading.mouseOver
             span.badge.pull-right=moment(timestamp).format("lll")
             h2.queue=val.queue
         hr
         if currentUrl === 'replays'
             div.btn-toolbar
-                button.modifyBtns.btn.btn-sm.btn-primary.retryButton(type="button" messageId=messageId logId=logId correlationId=correlationId index=logIndex text=val.text queue=val.queue)
+                button.modifyBtns.btn.btn-sm.btn-primary.retryButton(type="button" messageId=messageId logId=logId correlationId=correlationId index=logIndex text=val.text queue=val.queue connector=val.connector serializedMessage=val['serialized-form'] disabled=(val.connector == 'KafkaConnector'))
                     span.glyphicon.glyphicon-repeat
                     |  Retry
                 button.modifyBtns.btn.btn-sm.btn-primary.fixButton(type="button" messageId=messageId logId=logId correlationId=correlationId index=logIndex text=val.text queue=val.queue)
@@ -18,28 +18,28 @@ a.list-group-item
                 button.modifyBtns.btn.btn-sm.btn-success.changeQueueButton(type="button" messageId=messageId logId=logId correlationId=correlationId index=logIndex text=val.text queue=val.queue)
                     span.glyphicon.glyphicon-pencil
                     |  Change Queue
-                button.modifyBtns.btn.btn-sm.btn-info(onclick="window.location.href='log?id="+messageId+"'" data-toggle="tooltip" title="Opens log in a shareable url")
+                button.modifyBtns.btn.btn-sm.btn-info(onclick="window.location.href='log?id="+logId+"'" data-toggle="tooltip" title="Opens log in a shareable url")
                     span.glyphicon.glyphicon-link
                     | Share Link
         img.toggle-arrow.pull-right(src='img/toggle_arrow.svg', data-toggle='tooltip', title='Arrow')
-    div.collapse(id="listCollapse" + messageId)
+    div.collapse.listCollapse
         .row.listing-details
             span.badge
-                span Correlation ID: #{correlationId}
+                span #{val.connector} ID: #{correlationId}
         if val.text || val.errors
             if val.text
                 .btn-toolbar
-                    div.viewInfoBtn.btn.btn-sm.btn-info(data-toggle="collapse" data-target="#json" + messageId) View Json&nbsp;
+                    div.viewInfoBtn.btn.btn-sm.btn-info(data-toggle="collapse" data-target="#" + messageId + " .msgJson") View Json&nbsp;
                         span.glyphicon.glyphicon-chevron-down
-                div.collapse(id="json" + messageId)
+                div.collapse.msgJson
                     pre
                         code.json=JSON.stringify(val.text, null, 2)
             if val.errors
                 .btn-toolbar
-                    div.viewInfoBtn.btn.btn-sm.btn-danger(type="button" data-toggle="collapse" data-target="#error" + messageId) View Error&nbsp;
+                    div.viewInfoBtn.btn.btn-sm.btn-danger(type="button" data-toggle="collapse" data-target="#" + messageId + " .msgError") View Error&nbsp;
                         span.glyphicon.glyphicon-chevron-down
-                div.collapse(id="error" + messageId)
-                    pre(id="pre-error" + messageId)
+                div.collapse.msgError
+                    pre
                         code.java=val.errors
     if currentUrl == 'retries'
         h5.queue

--- a/views/layouts/log.jade
+++ b/views/layouts/log.jade
@@ -6,7 +6,7 @@ a.list-group-item(id=messageId)
         hr
         if currentUrl === 'replays'
             div.btn-toolbar
-                button.modifyBtns.btn.btn-sm.btn-primary.retryButton(type="button" messageId=messageId logId=logId correlationId=correlationId index=logIndex text=val.text queue=val.queue connector=val.connector serializedMessage=val['serialized-form'] disabled=(val.connector == 'KafkaConnector'))
+                button.modifyBtns.btn.btn-sm.btn-primary.retryButton(type="button" messageId=messageId logId=logId correlationId=correlationId index=logIndex text=val.text queue=val.queue connector=val.connector roleMessage=val['role-message'] role=val['role'])
                     span.glyphicon.glyphicon-repeat
                     |  Retry
                 button.modifyBtns.btn.btn-sm.btn-primary.fixButton(type="button" messageId=messageId logId=logId correlationId=correlationId index=logIndex text=val.text queue=val.queue)
@@ -15,7 +15,7 @@ a.list-group-item(id=messageId)
                 button.modifyBtns.btn.btn-sm.btn-success.changeStepButton(type="button" messageId=messageId logId=logId correlationId=correlationId index=logIndex text=val.text queue=val.queue)
                     span.glyphicon.glyphicon-step-forward
                     |  Change Step
-                button.modifyBtns.btn.btn-sm.btn-success.changeQueueButton(type="button" messageId=messageId logId=logId correlationId=correlationId index=logIndex text=val.text queue=val.queue disabled=(val.connector == 'KafkaConnector'))
+                button.modifyBtns.btn.btn-sm.btn-success.changeQueueButton(type="button" messageId=messageId logId=logId correlationId=correlationId index=logIndex text=val.text queue=val.queue)
                     span.glyphicon.glyphicon-pencil
                     |  Change Queue
                 button.modifyBtns.btn.btn-sm.btn-info(onclick="window.location.href='log?id="+logId+"'" data-toggle="tooltip" title="Opens log in a shareable url")

--- a/views/layouts/log.jade
+++ b/views/layouts/log.jade
@@ -47,6 +47,10 @@ a.list-group-item(id=log.messageId)
                 tr
                     th Index
                     td #{log.logIndex}
+                if log.stepCount
+                    tr
+                        th StepCount
+                        td #{log.stepCount}
 
         if log.val.text
             .btn-toolbar

--- a/views/layouts/log.jade
+++ b/views/layouts/log.jade
@@ -9,10 +9,10 @@ a.list-group-item(id=log.messageId)
                 button.modifyBtns.btn.btn-sm.btn-primary.retryButton(type="button" messageId=log.messageId logId=log.logId correlationId=log.correlationId index=log.logIndex destination=log.destination connector=log.connector roleMessage=log.roleMessage role=log.role version=log.version)
                     span.glyphicon.glyphicon-repeat
                     |  Retry
-                button.modifyBtns.btn.btn-sm.btn-primary.fixButton(type="button" messageId=log.messageId logId=log.logId correlationId=log.correlationId index=log.logIndex role=log.role)
+                button.modifyBtns.btn.btn-sm.btn-primary.fixButton(type="button" messageId=log.messageId logId=log.logId correlationId=log.correlationId index=log.logIndex role=log.role stepCount=log.stepCount)
                     span.glyphicon.glyphicon-ok
                     |  Fixed
-                button.modifyBtns.btn.btn-sm.btn-success.changeStepButton(type="button" messageId=log.messageId logId=log.logId correlationId=log.correlationId index=log.logIndex)
+                button.modifyBtns.btn.btn-sm.btn-success.changeStepButton(type="button" messageId=log.messageId logId=log.logId correlationId=log.correlationId index=log.logIndex destination=log.destination connector=log.connector roleMessage=log.roleMessage role=log.role version=log.version stepCount=log.stepCount)
                     span.glyphicon.glyphicon-step-forward
                     |  Change Step
                 button.modifyBtns.btn.btn-sm.btn-success.changeQueueButton(type="button" messageId=log.messageId logId=log.logId correlationId=log.correlationId index=log.logIndex)

--- a/views/layouts/log.jade
+++ b/views/layouts/log.jade
@@ -44,6 +44,9 @@ a.list-group-item(id=log.messageId)
                 tr
                     th LogVersion
                     td #{log.version}
+                tr
+                    th Index
+                    td #{log.logIndex}
 
         if log.val.text
             .btn-toolbar

--- a/views/layouts/log.jade
+++ b/views/layouts/log.jade
@@ -15,12 +15,16 @@ a.list-group-item(id=log.messageId)
                 button.modifyBtns.btn.btn-sm.btn-success.changeStepButton(type="button" messageId=log.messageId logId=log.logId correlationId=log.correlationId index=log.logIndex destination=log.destination connector=log.connector roleMessage=log.roleMessage role=log.role version=log.version stepCount=log.stepCount)
                     span.glyphicon.glyphicon-step-forward
                     |  Change Step
-                button.modifyBtns.btn.btn-sm.btn-success.changeQueueButton(type="button" messageId=log.messageId logId=log.logId correlationId=log.correlationId index=log.logIndex)
+                button.modifyBtns.btn.btn-sm.btn-success.sendToButton(type="button" messageId=log.messageId logId=log.logId correlationId=log.correlationId index=log.logIndex destination=log.destination connector=log.connector roleMessage=log.roleMessage role=log.role version=log.version sendType='role')
                     span.glyphicon.glyphicon-pencil
-                    |  Change Queue
+                    |  Change Role
+                if log.connector === "ActiveMQConnector"
+                    button.modifyBtns.btn.btn-sm.btn-success.sendToButton(type="button" messageId=log.messageId logId=log.logId correlationId=log.correlationId index=log.logIndex destination=log.destination connector=log.connector text=log.text role=log.role version=log.version sendType='raw')
+                        span.glyphicon.glyphicon-share-alt
+                        |  Change Queue
                 button.modifyBtns.btn.btn-sm.btn-info(onclick="window.location.href='log?id="+log.logId+"'" data-toggle="tooltip" title="Opens log in a shareable url")
                     span.glyphicon.glyphicon-link
-                    | Share Link
+                    |  Share Link
             img.toggle-arrow.pull-right(src='img/toggle_arrow.svg', data-toggle='tooltip', title='Arrow')
     div.collapse.listCollapse
         table.table

--- a/views/linked-log.jade
+++ b/views/linked-log.jade
@@ -24,7 +24,7 @@ html
                     - var maxRetryCount = val["forklift-retry-max-retries"];
                     - var display = retryCount == maxRetryCount ? true : false;
                     - var correlationId = logId
-                    - var messageId = logId;
+                    - var messageId = "message";
                     include layouts/log
 
     script(src='js/jquery-1.11.3.min.js')

--- a/views/linked-log.jade
+++ b/views/linked-log.jade
@@ -15,16 +15,7 @@ html
         div.container-fluid
             .row
                 .list-group
-                    - var val = log
-                    - var logId = val._id;
-                    - var logIndex = val._index;
-                    - val = val._source;
-                    - var timestamp = val.time;
-                    - var retryCount = val["forklift-retry-count"];
-                    - var maxRetryCount = val["forklift-retry-max-retries"];
-                    - var display = retryCount == maxRetryCount ? true : false;
-                    - var correlationId = logId
-                    - var messageId = "message";
+                    - log = extractLog(log, 0)
                     include layouts/log
 
     script(src='js/jquery-1.11.3.min.js')

--- a/views/log-display.jade
+++ b/views/log-display.jade
@@ -34,48 +34,17 @@ html
                     .list-group
                         .col-lg-6
                             - for(var i = 0; i < size; i+=2)
-                                - var val = hits[i];
-                                - var logId = val._id;
-                                - var logIndex = val._index;
-                                - val = val._source;
-                                - var timestamp = val.time;
-
-                                - var connector = val["destination-connector"] || "ActiveMQConnector";
-                                - var destination = val["destination-name"] || val["queue"];
-                                - var role = val["role"] || val["queue"];
-                                - var roleMessage = val["destination-message"] || val["text"];
-                                - var version = val["forklift-replay-version"];
-
-                                - var retryCount = val["forklift-retry-count"];
-                                - var maxRetryCount = val["forklift-retry-max-retries"];
-                                - var messageId = "message-" + i;
-                                - var display = currentUrl == 'retries' || retryCount == maxRetryCount ? true : false;
-                                - var correlationId = logId;
+                                - var log = extractLog(hits[i], i);
+                                - var display = currentUrl == 'retries' || log.val['forklift-retry-max-retries-exceeded'] == 'true';
                                 if display == true
                                     include layouts/log
 
                         .col-lg-6
                             - for(var i = 1; i < size; i+=2)
-                                - var val = hits[i];
-                                - var logId = val._id;
-                                - var logIndex = val._index;
-                                - val = val._source;
-                                - var timestamp = val.time;
-
-                                - var connector = val["destination-connector"] || "ActiveMQConnector";
-                                - var destination = val["destination-name"] || val["queue"];
-                                - var role = val["role"] || val["queue"];
-                                - var roleMessage = val["destination-message"] || val["text"];
-                                - var version = val["forklift-replay-version"];
-
-                                - var retryCount = val["forklift-retry-count"];
-                                - var maxRetryCount = val["forklift-retry-max-retries"];
-                                - var messageId = "message-" + i;
-                                - var display = currentUrl == 'retries' || retryCount == maxRetryCount ? true : false;
-                                - var correlationId = logId;
+                                - var log = extractLog(hits[i], i);
+                                - var display = currentUrl == 'retries' || log.val['forklift-retry-max-retries-exceeded'] == 'true';
                                 if display == true
-                                    include layouts/log
-
+                                  include layouts/log
             else
                 div.alert.alert-success
                     - var logType = currentUrl === 'replays' ? 'REPLAY' : 'RETRY'

--- a/views/log-display.jade
+++ b/views/log-display.jade
@@ -39,42 +39,47 @@ html
                                 - var logIndex = val._index;
                                 - val = val._source;
                                 - var timestamp = val.time;
+
+                                - var connector = val["destination-connector"] || "ActiveMQConnector";
+                                - var destination = val["destination-name"] || val["queue"];
+                                - var role = val["role"] || val["queue"];
+                                - var roleMessage = val["destination-message"] || val["text"];
+                                - var version = val["forklift-replay-version"];
+
                                 - var retryCount = val["forklift-retry-count"];
                                 - var maxRetryCount = val["forklift-retry-max-retries"];
                                 - var messageId = "message-" + i;
-                                if currentUrl == 'replays'
-                                    - var display = retryCount == maxRetryCount ? true : false;
-                                    - var correlationId = logId
-                                    if display == true
-                                        include layouts/log
-                                else
-                                    - val = JSON.parse(val["forklift-retry-msg"])
-                                    - var correlationId = val.headers.CorrelationId;
+                                - var display = currentUrl == 'retries' || retryCount == maxRetryCount ? true : false;
+                                - var correlationId = logId;
+                                if display == true
                                     include layouts/log
+
                         .col-lg-6
                             - for(var i = 1; i < size; i+=2)
-                                - var val = hits[i]
+                                - var val = hits[i];
                                 - var logId = val._id;
                                 - var logIndex = val._index;
                                 - val = val._source;
                                 - var timestamp = val.time;
+
+                                - var connector = val["destination-connector"] || "ActiveMQConnector";
+                                - var destination = val["destination-name"] || val["queue"];
+                                - var role = val["role"] || val["queue"];
+                                - var roleMessage = val["destination-message"] || val["text"];
+                                - var version = val["forklift-replay-version"];
+
                                 - var retryCount = val["forklift-retry-count"];
                                 - var maxRetryCount = val["forklift-retry-max-retries"];
                                 - var messageId = "message-" + i;
-                                if currentUrl == 'replays'
-                                    - var display = retryCount == maxRetryCount ? true : false;
-                                    - var correlationId = logId
-                                    if display == true
-                                        include layouts/log
-                                else
-                                    - val = JSON.parse(val["forklift-retry-msg"])
-                                    - var correlationId = val.headers.CorrelationId;
+                                - var display = currentUrl == 'retries' || retryCount == maxRetryCount ? true : false;
+                                - var correlationId = logId;
+                                if display == true
                                     include layouts/log
 
             else
                 div.alert.alert-success
-                    - var queue = currentUrl === 'replays' ? 'REPLAY' : 'RETRY'
-                    h1.noListings.text-center NO #{queue} LOGS FOUND
+                    - var logType = currentUrl === 'replays' ? 'REPLAY' : 'RETRY'
+                    h1.noListings.text-center NO #{logType} LOGS FOUND
 
     script(src='js/jquery-1.11.3.min.js')
     script(src='js/bootstrap.min.js')

--- a/views/log-display.jade
+++ b/views/log-display.jade
@@ -35,14 +35,14 @@ html
                         .col-lg-6
                             - for(var i = 0; i < size; i+=2)
                                 - var log = extractLog(hits[i], i);
-                                - var display = currentUrl == 'retries' || log.val['forklift-retry-max-retries-exceeded'] == 'true';
+                                - var display = currentUrl == 'retries' || log.retriesDone;
                                 if display == true
                                     include layouts/log
 
                         .col-lg-6
                             - for(var i = 1; i < size; i+=2)
                                 - var log = extractLog(hits[i], i);
-                                - var display = currentUrl == 'retries' || log.val['forklift-retry-max-retries-exceeded'] == 'true';
+                                - var display = currentUrl == 'retries' || log.retriesDone;
                                 if display == true
                                   include layouts/log
             else

--- a/views/log-display.jade
+++ b/views/log-display.jade
@@ -34,23 +34,22 @@ html
                     .list-group
                         .col-lg-6
                             - for(var i = 0; i < size; i+=2)
-                                - var val = hits[i]
+                                - var val = hits[i];
                                 - var logId = val._id;
                                 - var logIndex = val._index;
                                 - val = val._source;
                                 - var timestamp = val.time;
                                 - var retryCount = val["forklift-retry-count"];
                                 - var maxRetryCount = val["forklift-retry-max-retries"];
+                                - var messageId = "message-" + i;
                                 if currentUrl == 'replays'
                                     - var display = retryCount == maxRetryCount ? true : false;
                                     - var correlationId = logId
-                                    - var messageId = logId;
                                     if display == true
                                         include layouts/log
                                 else
                                     - val = JSON.parse(val["forklift-retry-msg"])
                                     - var correlationId = val.headers.CorrelationId;
-                                    - var messageId = val.messageId;
                                     include layouts/log
                         .col-lg-6
                             - for(var i = 1; i < size; i+=2)
@@ -61,16 +60,15 @@ html
                                 - var timestamp = val.time;
                                 - var retryCount = val["forklift-retry-count"];
                                 - var maxRetryCount = val["forklift-retry-max-retries"];
+                                - var messageId = "message-" + i;
                                 if currentUrl == 'replays'
                                     - var display = retryCount == maxRetryCount ? true : false;
                                     - var correlationId = logId
-                                    - var messageId = logId;
                                     if display == true
                                         include layouts/log
                                 else
                                     - val = JSON.parse(val["forklift-retry-msg"])
                                     - var correlationId = val.headers.CorrelationId;
-                                    - var messageId = val.messageId;
                                     include layouts/log
 
             else


### PR DESCRIPTION
#### Changes:
- Add ability to send pre-serialized messages to Kafka
- Resolve Kafka connection address using consul
- Add ability to set version when updating logs in elasticsearch
- Read new properties off of replay and retry logs in a backward-compatible way
- Redo a bunch of the wording; forklift is no longer limited to queues
- Allow message log ID to contain `.` or `:` (two separate issues)
    - `.` is likely in kafka's log IDs because internally topic name is currently the same as the class name of the event produced to it
    - `:` is guaranteed in my local IDs generated by AMQ, in which case elasticsearch cannot search for the log ID because `:` is a special character in the `query_string` query.
- Allow the "Change Queue" function only for AMQ replay logs, have it be distinctly different from the "Change Role" function which is supported generically by AMQ an Kafka

#### Minor Changes:
- Make JSON not be escaped (don't need to `stringify` a string that contains already stringified JSON)
- A few cleanup things

#### Notes:
- These changes try to transparently preserve compatibility with the old replay system; it would be wise to remove the compatibility code once it is no longer needed.
- This corresponds to a major rework of replay and retry in forklift: https://github.com/dcshock/forklift/pull/128