### PR TITLE
Fix "Fix All" and "Retry All"

### DIFF
--- a/controllers/elasticSearchController.js
+++ b/controllers/elasticSearchController.js
@@ -71,45 +71,9 @@ module.exports.updateAllAsFixed = function(req, res) {
 };
 
 module.exports.retry = function(req, res) {
-    var connector = req.body.connector;
-    var version = req.body.version;
-
-    var destination = req.body.destination;
-    var roleMessage = req.body.roleMessage;
-
-    var role = req.body.role;
-    var correlationId = req.body.correlationId;
-
-    if (version && version == '2') {
-        logger.info('Retrying message for role "' + role + '" to connector "' + connector + '"');
-        if (connector === 'KafkaConnector') {
-            elasticService.sendToKafka({
-                topic: destination,
-                message: {
-                    value: Buffer.from(roleMessage, 'base64')
-                }
-            }, function() {
-                res.end();
-            });
-        } else if (connector === 'ActiveMQConnector') {
-            elasticService.sendToActiveMq({
-                queue: destination,
-                body: roleMessage,
-                jmsHeaders: {'correlation-id': correlationId}
-            }, function() {
-                res.end();
-            });
-        }
-    } else {
-        logger.info('Assuming message with unrecognized version "' + version + '" is a legacy message for activemq queue "' + destination + '"');
-        elasticService.sendToActiveMq({
-            queue: destination,
-            body: roleMessage,
-            jmsHeaders: {'correlation-id': correlationId}
-        }, function() {
-            res.end();
-        });
-    }
+    elasticService.retry(req.body, function() {
+        res.end();
+    });
 };
 
 module.exports.retryAll = function(req, res) {
@@ -119,8 +83,7 @@ module.exports.retryAll = function(req, res) {
             req.flash('error', err);
         }
         for (var i = 0; i < logs.length; i++) {
-            elasticService.retry(logs[i]._id, logs[i]._source.text, queue, function() {
-            })
+            elasticService.retry(extractLog(logs[i]), function() {})
         }
         res.send("done");
     });

--- a/controllers/elasticSearchController.js
+++ b/controllers/elasticSearchController.js
@@ -113,8 +113,8 @@ module.exports.retry = function(req, res) {
 };
 
 module.exports.retryAll = function(req, res) {
-    var queue = req.body.queue;
-    elasticService.poll('replay', queue, 10000, function(logs, err) {
+    var role = req.body.role;
+    elasticService.poll('replay', role, 10000, function(logs, err) {
         if (logs === 'undefined' || logs == null) {
             req.flash('error', err);
         }

--- a/public/javascripts/dashboard.js
+++ b/public/javascripts/dashboard.js
@@ -1,15 +1,15 @@
 $('[data-toggle="tooltip"]').tooltip();
 $(".fixBtn").click(function() {
-    var queue = $(this).attr('queue');
+    var role = $(this).attr('role');
     swal({
         title: "Are you sure?",
-        text: "This will set all [ " + queue + " ] replay logs as fixed.",
+        text: "This will set all [ " + role + " ] replay logs as fixed.",
         type: "warning",
         showCancelButton: true,
         confirmButtonText: 'Yes, Fix them!'
     }, function() {
         $.post('fixAll', {
-            queue: queue
+            role: role
         }, function() {
             setTimeout(function() {
                 location.reload();
@@ -18,10 +18,10 @@ $(".fixBtn").click(function() {
     });
 });
 $(".retryBtn").click(function() {
-    var queue = $(this).attr('queue');
+    var role = $(this).attr('role');
     swal({
         title: "Are you sure?",
-        text: "This will retry all [ " + queue + " ] replay logs.",
+        text: "This will retry all [ " + role + " ] replay logs.",
         type: "warning",
         showCancelButton: true,
         confirmButtonColor: '#3085d6',
@@ -29,7 +29,7 @@ $(".retryBtn").click(function() {
         confirmButtonText: 'Yes, Retry them!'
     }, function() {
         $.post('retryAll', {
-            queue: queue
+            role: role
         }, function() {
             setTimeout(function() {
                 location.reload();

--- a/views/dashboard.jade
+++ b/views/dashboard.jade
@@ -49,9 +49,9 @@ html
                                 - for (var role in stats.replay.roleTotals)
                                     - var roleTotal = stats.replay.roleTotals[role]
                                     a.queueBtn.btn.btn-info.btn-lg.text-uppercase(href="filtered?service=replays&role=" + role) #{role} - #{roleTotal}
-                                    .btn.queueModBtn.retryBtn.btn-primary.btn-lg.text-uppercase(queue=queue data-toggle="tooltip" title="Will retry all logs in queue")
+                                    .btn.queueModBtn.retryBtn.btn-primary.btn-lg.text-uppercase(role=role data-toggle="tooltip" title="Will retry all logs for this role")
                                         span.glyphicon.glyphicon-retweet
-                                    .btn.queueModBtn.fixBtn.btn-danger.btn-lg.text-uppercase(queue=queue data-toggle="tooltip" title="Will mark all logs in queue as fixed")
+                                    .btn.queueModBtn.fixBtn.btn-danger.btn-lg.text-uppercase(role=role data-toggle="tooltip" title="Will mark all logs for this role as fixed")
                                         span.glyphicon.glyphicon-fire
                             else
                                 div.alert.alert-success


### PR DESCRIPTION
#### Changes:
- Move the "retry" function back to elastic-service
- Properly switch all the "queue" references to "role" (since we're trying to use more generic wording)

This fixes the issue with "Fix All" and "Retry All" on the main page where it would pick up `undefined` as the role to act on because of not properly renaming variable references.

From there, if continued, "Fix All" would apply to all would apply to all messages instead of those with just that role because of javascript's treatment of `undefined`.

#### Testing:
- Ensure that logs for other roles aren't affected when doing the following:
    - Tested that multiple error messages are resent to the ActiveMQ echo consumer with "retry all" and return to an error state, and can then all be fixed together with "fix all"
    - Did similar testing for a simple Kafka consumer
- Tested that normal retry still works for Kafka and ActiveMQ, since the function got refactored a little
----

Please Review:
@ShaneIsrael @shirigulax 