### PR TITLE
Remove Unsupported Extra Query Params to ES HEAD Check

### DIFF
--- a/services/elasticService.js
+++ b/services/elasticService.js
@@ -45,9 +45,7 @@ function stompConnect() {
 service.ping = function(done) {
     client.ping({
         // ping usually has a 3000ms timeout
-        requestTimeout: 3000,
-        // undocumented params are appended to the query string
-        hello: "elasticsearch!"
+        requestTimeout: 3000
     }, function (error) {
         if (error) {
             done(false);


### PR DESCRIPTION
#### Changes:
* Change ping to elasticsearch to remove query params

Later versions of elasticsearch after 2.5 (at least ES5) no longer support query parameters to the health check endpoint and instead return `400`s if they are given. This should fix it so that these versions of elasticsearch don't needlessly appear as unavailable.

----

Please Review: @shirigulax 