### PR TITLE
Overwrite Version for Incorrectly Versioned Logs

### DIFF
--- a/services/elasticService.js
+++ b/services/elasticService.js
@@ -124,13 +124,10 @@ service.update = function(index, updateId, step, version, done) {
             doc: {
                 step: step
             }
-        }
+        },
+        versionType: 'force',
+        version: version || 1
     };
-
-    if (version) {
-        updateRequest.version = version;
-        updateRequest.versionType = 'force';
-    }
 
     client.update(updateRequest, function (err) {
         if (err) {


### PR DESCRIPTION
#### Problem:
As a result of using `external_gte` versioning within an index, it can become the default version type for indexing (probably only if that is the first version type used in that index). This means that anything that wrote logs to the `forklift-replay*` indexes and wasn't updated after we started using `external_gte`, would get the default version of `0` for that log instead of the normal default for `internal` versioned messages of `1`.

Since there is no `external_gte` version type for updating (or deleting) logs in elasticsearch, it instead defaults to `internal`. This means that we end up using an invalid version for the `internal` version type (`0`) and end up with a validation error: `illegal version value [0] for version type [INTERNAL]`.

This makes it impossible to update a replay log in forklift-gui currently for incorrectly versioned logs.

#### Solution:
Use a different version type for updating replay logs - `force`, and use that to make the version valid version for logs with an `internal` version type (so other default requests should work on these logs).

#### Notes:
This change may break make replay logging for consumers running pre forklift-2.0 if the log is first updated in forklift-gui, and then retried.

----

Please Review: @shirigulax 