### PR TITLE
Make successfully sent messages appear as 'Retry Sent' in ES

### DIFF
--- a/public/javascripts/hits.js
+++ b/public/javascripts/hits.js
@@ -65,6 +65,11 @@ $("#fixAllButton").click(function() {
 $('.retryButton').click(function () {
     var messageId = $(this).attr('messageId');
 
+    // properties for performing step changes
+    var updateId = $(this).attr('logId');
+    var index = $(this).attr('index');
+    var stepCount = $(this).attr('stepCount');
+
     var connector  = $(this).attr('connector');
     var version = $(this).attr('version');
     var role = $(this).attr('role');
@@ -74,6 +79,10 @@ $('.retryButton').click(function () {
     var correlationId = $(this).attr('correlationId');
 
     var retryMsg = {
+        updateId: updateId,
+        index: index,
+        stepCount: stepCount,
+
         connector: connector,
         role: role,
         destination: destination,


### PR DESCRIPTION
#### Effect: 
Messages shouldn't appear to not send in the GUI, while actually queuing up several copies in the broker, since unretried messages will have a different status.

#### Changes:
- Send "Retry Sent" status update before sending a retry message
- Set the log's status to error if the retry failed 

The reasoning for sending the "Retry Sent" update first, is to avoid a race condition with the consumer that receives the update. If the update turns out to have been incorrect, then it should be reverted.

This introduces another minor error state for logs in ES - if something is stuck in "Processing" or "Retry Sent" for a long period then something went wrong internally.

#### Testing:
- Created an intentional error for the GUI using an activemq consumer
- Retried the error normally, and observed it cycle back through retry into replay
- Turned off the consumer, and retried the errored message. Observed the message no longer appearing in the GUI but being listed with a `step` of `Retry Sent` in ES

---
Please Review: @JakeSchwartz-SoFi 